### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,10 +1,10 @@
 
 function _git_branch_name
-  echo (command git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
+  echo (command git symbolic-ref HEAD 2> /dev/null | sed -e 's|^refs/heads/||')
 end
 
 function _is_git_dirty
-  echo (command git status -s --ignore-submodules=dirty ^/dev/null)
+  echo (command git status -s --ignore-submodules=dirty 2> /dev/null)
 end
 
 ## Function to show a segment

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -7,7 +7,7 @@ function fish_right_prompt
   end
 
   # Timestamp
-  set_color $fish_color_autosuggestion ^/dev/null; or set_color 555
+  set_color $fish_color_autosuggestion 2> /dev/null; or set_color 555
   echo (date "+%H:%M:%S")
 
 end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618