### PR TITLE
feat: add last command duration, refine right prompt position

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,7 @@ $ fisher rm theme-eden
 
 ## Screenshot
 
-<p align="center">
-<img width="883" height="529" alt="Theme Eden Screenshot" src="https://cloud.githubusercontent.com/assets/215282/14846313/c3e211f0-0c95-11e6-8814-93a2b9a78b2c.png">
-</p>
-
-Font: [INCONSOLATA](https://www.google.com/fonts/specimen/Inconsolata)
+![Fish Shell theme Eden screenshot](https://github.com/amio/fish-theme-eden/assets/215282/fd437f9b-acfe-473b-b6e6-fa28f92ff7c1)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ fisher rm theme-eden
 
 ## Features
 
-* Last command's timestamp & exit status on right.
+* Last command's **timestamp**, **duration**, and **exit status**(if not zero) on right.
 * `eden_toggle_path` display long or short pwd.
 * `eden_toggle_host` show or hide host & user.
 * `eden_prompt_char` custom prompt char.

--- a/fish_greeting.fish
+++ b/fish_greeting.fish
@@ -9,4 +9,10 @@
 #
 
 function fish_greeting
+  # cleanup fish_greeting
+end
+
+# Append a new line to every command result
+function postexec_newline --on-event fish_postexec
+   echo # add newline after command outputs
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -90,10 +90,8 @@ function show_prompt_char -d "Terminate with a nice prompt char"
 end
 
 function fish_prompt
-  set fish_greeting
-
-  # The newline before prompts
-  echo ''
+  # use tput to move cursor to line start
+  echo -ne (tput cr)
 
   show_ssh_status
   show_host

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -15,7 +15,16 @@ function fish_right_prompt
   
   # Output the duration of the last command
   if test $CMD_DURATION -ne 0
-    echo "$CMD_DURATION""ms "
+    if test $CMD_DURATION -ge 60000
+      set -l duration_minutes (math "floor($CMD_DURATION / 60000)")
+      set -l duration_seconds (math "round(($CMD_DURATION % 60000) / 1000)")
+      printf "%02d:%02d " $duration_minutes $duration_seconds
+    else if test $CMD_DURATION -ge 1000
+      set -l duration_seconds (math "round($CMD_DURATION / 1000)")
+      echo "$duration_seconds""s "
+    else
+      echo "$CMD_DURATION""ms "
+    end
   end
 
   # Output the current time

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -2,12 +2,26 @@ function fish_right_prompt
 
   # Last command status
   set -l code $status
+
+  # https://github.com/fish-shell/fish-shell/issues/3476#issuecomment-256058730
+  # Save the cursor position, move it up one line, and move it to the right two spaces
+  tput sc; tput cuu1; tput cuf 2
+
   if test $code != 0
-    echo -s (set_color red) '-' $code '- '
+    echo -ns (set_color red) '-' $code '- '
   end
 
-  # Timestamp
   set_color $fish_color_autosuggestion 2> /dev/null; or set_color 555
+  
+  # Output the duration of the last command
+  if test $CMD_DURATION -ne 0
+    echo "$CMD_DURATION""ms "
+  end
+
+  # Output the current time
   echo (date "+%H:%M:%S")
+
+  # Restores the cursor position
+  tput rc
 
 end


### PR DESCRIPTION
- Add the last command's duration.
-  Move the right prompt's position up by one line.

<img width="785" alt="image" src="https://github.com/oh-my-fish/theme-eden/assets/215282/9473be66-d2b9-43f5-8cce-650599ce3111">
